### PR TITLE
feat: split cardano-node env vars

### DIFF
--- a/roles/cardano_node/defaults/main.yml
+++ b/roles/cardano_node/defaults/main.yml
@@ -9,12 +9,12 @@ cardano_node_version: '1.35.3'
 cardano_node_dir: /opt/cardano
 
 # DB directory for host/container
-cardano_node_db_dir: '{{ cardano_node_dir }}/db'
-cardano_node_db_container_dir: '/data/db'
+cardano_node_db_dir: '{{ cardano_node_dir }}/data'
+cardano_node_db_container_dir: '{{ cardano_node_db_dir }}'
 
 # IPC directory for host/container
 cardano_node_ipc_dir: '{{ cardano_node_dir }}/ipc'
-cardano_node_ipc_container_dir: '/ipc'
+cardano_node_ipc_container_dir: '{{ cardano_node_ipc_dir }}'
 
 # User/group for file/directory ownership
 cardano_node_user: root
@@ -42,3 +42,6 @@ cardano_node_socket_name: node.socket
 
 # Cardano network
 cardano_node_network: mainnet
+
+# Topology
+cardano_node_topology_file: '{{ cardano_node_dir }}/config/{{ cardano_node_network }}-topology.json'

--- a/roles/cardano_node/tasks/docker.yml
+++ b/roles/cardano_node/tasks/docker.yml
@@ -16,7 +16,12 @@
       - '{{ cardano_node_port }}:{{ cardano_node_container_port }}'
       - '{{ cardano_node_metrics_port }}:{{ cardano_node_metrics_container_port }}'
     env:
-      NETWORK: '{{ cardano_node_network }}'
+      CARDANO_CONFIG: '{{ cardano_node_dir }}/config/{{ cardano_node_network }}-config.json'
+      CARDANO_DATABASE_PATH: '{{ cardano_node_db_container_dir }}'
+      CARDANO_NODE_SOCKET_PATH: '{{ cardano_node_ipc_container_dir }}/{{ cardano_node_socket_name }}'
+      CARDANO_PORT: '{{ cardano_node_port | string }}'
+      CARDANO_SOCKET_PATH: '{{ cardano_node_ipc_container_dir }}/{{ cardano_node_socket_name }}'
+      CARDANO_TOPOLOGY: '{{ cardano_node_topology_file }}'
     volumes:
       - '{{ cardano_node_db_dir }}:{{ cardano_node_db_container_dir }}'
       - '{{ cardano_node_ipc_dir }}:{{ cardano_node_ipc_container_dir }}'


### PR DESCRIPTION
Use the split variables for the cardano-node container image instead of the helper `NETWORK` variable.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>